### PR TITLE
Make tests not crash

### DIFF
--- a/liboptv/include/sortgrid.h
+++ b/liboptv/include/sortgrid.h
@@ -18,7 +18,7 @@ target* sortgrid (Calibration* cal, control_par *cpar, int nfix, vec3d fix[], in
     int eps, target pix[]);				
 int nearest_neighbour_pix (target pix[], int num, double x, double y, double eps);
 int read_sortgrid_par(char *filename);
-int read_calblock(vec3d fix[], char* filename);
+vec3d *read_calblock(int* num_points, char* filename);
 
 #endif
 

--- a/liboptv/src/orientation.c
+++ b/liboptv/src/orientation.c
@@ -618,7 +618,7 @@ int raw_orient (Calibration* cal, control_par *cpar, int nfix, vec3d fix[], targ
 {
     double  X[10][6], y[10], XPX[6][6], XPy[6], beta[6];
     int     i, j, n, itnum, stopflag;
-    double  dm = 0.0001,  drad = 0.000001;
+    double  dm = 0.0001,  drad = 0.0001;
     double 	xp, yp, xpd, ypd, xc, yc, r, qq, p, sumP;
     vec3d   pos;
 

--- a/liboptv/src/orientation.c
+++ b/liboptv/src/orientation.c
@@ -3,6 +3,8 @@
 #include "calibration.h"
 #include "ray_tracing.h"
 #include "vec_utils.h"
+#include "sortgrid.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -759,13 +761,13 @@ int raw_orient (Calibration* cal, control_par *cpar, int nfix, vec3d fix[], targ
    Returns:
    int number of points, should be 4. If reading failed for any reason, returns NULL.
 */
-int read_man_ori_fix(vec3d fix4[4], char* calblock_filename, char* man_ori_filename,
-                    int cam){
+int read_man_ori_fix(vec3d fix4[4], char* calblock_filename, 
+    char* man_ori_filename, int cam)
+{
     FILE* fpp;
-    int	dummy, pnr, k = 0, nr[4],i;
-    vec3d fix;
-
-
+    int	dummy, pnr, nr[4],i;
+    int num_fix, num_match;
+    vec3d *fix;
 
     fpp = fopen(man_ori_filename,"r");
     if (! fpp) {
@@ -778,31 +780,26 @@ int read_man_ori_fix(vec3d fix4[4], char* calblock_filename, char* man_ori_filen
     fscanf (fpp, "%d %d %d %d \n", &nr[0], &nr[1], &nr[2], &nr[3]);
     fclose (fpp);
 
-    fpp = fopen (calblock_filename, "r");
-    if (! fpp) {
-        printf("Can't open calibration block file: %s\n", calblock_filename);
+    /* read the id and positions of the fixed points, assign the pre-defined to fix4 */
+    fix = read_calblock(&num_fix, calblock_filename);
+    if (num_fix < 4) {
+        printf("Too few points or incompatible file: %s\n", calblock_filename);
         goto handle_error;
     }
-
-    /* read the id and positions of the fixed points, assign the pre-defined to fix4 */
-    while (fscanf(fpp, "%d %lf %lf %lf\n", &(pnr),&(fix[0]),
-            &(fix[1]),&(fix[2])) == 4){
-            if      (pnr == nr[0]) {vec_copy(fix4[0], fix); k++;}
-            else if (pnr == nr[1]) {vec_copy(fix4[1], fix); k++;}
-            else if (pnr == nr[2]) {vec_copy(fix4[2], fix); k++;}
-            else if (pnr == nr[3]) {vec_copy(fix4[3], fix); k++;}
+    
+    num_match = 0; /* count matches to needed numbers */
+    for (pnr = 0; pnr < num_fix; pnr++) {
+        for (i = 0; i < 4; i++) {
+            if (pnr == nr[i] - 1) {
+                vec_copy(fix4[i], fix[pnr]);
+                num_match++;
+                break;
+            }
         }
-
-    fclose (fpp);
-
-
-    if (k != 4) {
-        printf("Empty or incompatible file: %s\n", calblock_filename);
-        goto handle_error;
-      }
-
-    fclose (fpp);
-	return k;
+        if (num_match >= num_fix) break;
+    }
+    
+	return num_match;
 
 handle_error:
     if (fpp != NULL) fclose (fpp);

--- a/liboptv/src/sortgrid.c
+++ b/liboptv/src/sortgrid.c
@@ -161,9 +161,11 @@ handle_error:
    Returns:
    int number of valid calibration points. If reading failed for any reason, returns NULL.
 */
-int read_calblock(vec3d fix[], char* filename) {
-    FILE* fpp;
+vec3d* read_calblock(int *num_points, char* filename) {
+    FILE* fpp = NULL;
     int	dummy, k = 0;
+    vec3d fix;
+    vec3d *ret = (vec3d *) malloc(1); /* reallocated every line */
        
     fpp = fopen (filename, "r");
     if (! fpp) {
@@ -171,8 +173,14 @@ int read_calblock(vec3d fix[], char* filename) {
         goto handle_error;
     }
     
-    while (fscanf(fpp, "%d %lf %lf %lf\n", &(dummy),&(fix[k][0]),
-            &(fix[k][1]),&(fix[k][2])) == 4) k++;
+    /* Two passes: one counts lines and one allocates memory.*/
+    while (fscanf(fpp, "%d %lf %lf %lf\n", &(dummy),&(fix[0]),
+            &(fix[1]),&(fix[2])) == 4) 
+    {
+        ret = (vec3d *) realloc(ret, (k + 1) * sizeof(vec3d));
+        vec_copy(ret[k], fix);
+        k++;
+    }
     
     fclose (fpp);
 
@@ -183,7 +191,8 @@ int read_calblock(vec3d fix[], char* filename) {
       }
     
     fclose (fpp);
-	return k;
+    *num_points = k;
+	return ret;
 
 handle_error:
     if (fpp != NULL) fclose (fpp);

--- a/liboptv/src/sortgrid.c
+++ b/liboptv/src/sortgrid.c
@@ -188,7 +188,7 @@ vec3d* read_calblock(int *num_points, char* filename) {
     if (k == 0) {
         printf("Empty of badly formatted file: %s\n", filename);
         goto handle_error;
-      }
+    }
     
     fclose (fpp);
     *num_points = k;
@@ -196,5 +196,7 @@ vec3d* read_calblock(int *num_points, char* filename) {
 
 handle_error:
     if (fpp != NULL) fclose (fpp);
-    return 0;
+    *num_points = 0;
+    free(ret);
+    return NULL;
 }

--- a/liboptv/tests/check_orientation.c
+++ b/liboptv/tests/check_orientation.c
@@ -60,7 +60,6 @@ START_TEST(test_raw_orient)
         metric_to_pixel (&(pix4[i].x), &(pix4[i].y), xp, yp, cpar);
     }
 
-
     fail_if((org_cal = read_calibration(ori_file, add_file, NULL)) == NULL);
 
     /* fake the pix points by back-projection */

--- a/liboptv/tests/check_sortgrid.c
+++ b/liboptv/tests/check_sortgrid.c
@@ -55,18 +55,16 @@ END_TEST
 START_TEST(test_read_calblock)
 {
     int num_points, correct_num_points = 5;
-    vec3d fix[100];
+    vec3d *fix;
     char calblock_file[] = "testing_fodder/cal/calblock.txt";
     
-
     ck_assert_msg (file_exists(calblock_file) == 1, 
         "\n File %s does not exist\n", calblock_file);
-    num_points = read_calblock(fix, calblock_file);   
-    fail_if (num_points == 0, "\n calblock file reading failed \n");
-
-    fail_unless(num_points == correct_num_points);
     
-
+    fix = read_calblock(&num_points, calblock_file);   
+    
+    fail_if (num_points == 0, "\n calblock file reading failed \n");
+    fail_unless(num_points == correct_num_points);
 }
 END_TEST
 
@@ -74,7 +72,7 @@ START_TEST(test_sortgrid)
 {
     Calibration *cal;
     control_par *cpar;
-    vec3d fix[100];
+    vec3d *fix;
     target pix[2];
     target *sorted_pix;
     int nfix, i;
@@ -96,10 +94,9 @@ START_TEST(test_sortgrid)
     char add_file[] = "testing_fodder/cal/cam1.tif.addpar";
 
     fail_if((cal = read_calibration(ori_file, add_file, NULL)) == 0);
-
     fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par")) == 0);
-
-    fail_if((nfix = read_calblock(fix,"testing_fodder/cal/calblock.txt")) != 5);   
+    fail_if((fix = read_calblock(&nfix,"testing_fodder/cal/calblock.txt")) == NULL);
+    fail_unless(nfix == 5);
 
     sorted_pix = sortgrid (cal, cpar, nfix, fix, targets_read, eps, pix);
     fail_unless(sorted_pix[0].pnr == -999);


### PR DESCRIPTION
The orientation and reading tests crashed on my system. Possibly due to missing files? They still don't pass, mind you, but we are making progress. raw_orient passes after I changed drad. But raw_orient will get some more handling on the next iteration...