### PR TITLE
Separate frame-buffer to a base class and child class.

### DIFF
--- a/liboptv/CMakeLists.txt
+++ b/liboptv/CMakeLists.txt
@@ -4,9 +4,9 @@ set (CMAKE_INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 project(OpenPTV)
-# enable_testing()
+enable_testing()
 add_subdirectory(src)
-# add_subdirectory(tests)
+add_subdirectory(tests)
 
 INSTALL(DIRECTORY include/ DESTINATION include/optv/)
 

--- a/liboptv/include/tracking_frame_buf.h
+++ b/liboptv/include/tracking_frame_buf.h
@@ -82,11 +82,72 @@ int write_frame(frame *self, char *corres_file_base, char *linkage_file_base,
     char *prio_file_base, char **target_file_base, int frame_num);
 
 
+/*
+ * Following is the frame buffer class, that holds a given number of frame structs,
+ * and treats them as a deque (doube-ended queue, a queue that can advance forward 
+ * or backward).
+ * 
+ * The memory locations are advanced with fb_next()/fb_prev(). Filling out the new
+ * frame that joined the queue and flushing out the frame that exited the queue 
+ * are respectively done using fb_read_frame_at_end() and fb_write_frame_from_start().
+ * 
+ * To make it possible to read frames from different sources, we use a 
+ * base-class/child-class structure. framebuf_base is the base class, and implements
+ * only the memory-advance methods. The filling-out of frames is done by 
+ * "virtual" functions. That is to say, fb_read_frame_at_end, for example,
+ * only forwards the call to a function that really reads the data.
+ * 
+ * The virtual functions are placed in the "vtable" by the constructor - the 
+ * function that allocates and populates the child class. 
+ * 
+ * In tracking_framebuf.c and here there's an example child-class that reads 
+ * frame information from *_target files. This is the original mode of 
+ * liboptv. The struct framebuf *inherits* from framebuf_base (by incorporating
+ * the base as 1st member - the order is important). fb_init(), the constructor,
+ * then populates the vtable with fb_disk_* functions. These are the derived
+ * implementations of the base-class virtual functions. 
+ * 
+ * There is also a virtual destructor, fb_free(), which delegates to the free() 
+ * virtual function, and implemented in the example by fb_disk_free().
+ * 
+ * Note: fb_disk_free does not release the strings it holds, as I don't remember if
+ * it owns them. 
+ * 
+ * Yes, in C++ it's easier :)
+ */
+
+// Virtual function table definitions for frame buffer objects:
+typedef struct framebuf_base* fbp;
 typedef struct {
+    void (*free)(fbp self);
+    int (*read_frame_at_end)(fbp self, int frame_num, int read_links);
+    int (*write_frame_from_start)(fbp self, int frame_num);
+} fb_vtable;
+
+typedef struct framebuf_base {
+    fb_vtable *_vptr;
+    
     /* _ring_vec is the underlying double-size vector, buf is the pointer to 
     the start of the ring. */
     frame **buf, **_ring_vec;
     int buf_len, num_cams;
+} framebuf_base;
+
+// These just call the corresponding virtual function. 
+// Actual implementations are below each child class.
+void fb_free(framebuf_base *self);
+int fb_read_frame_at_end(framebuf_base *self, int frame_num, int read_links);
+int fb_write_frame_from_start(framebuf_base *self, int frame_num);
+
+// Non-virtual methods of the base class.
+void fb_base_init(framebuf_base *new_buf, int buf_len, int num_cams, int max_targets);
+void fb_next(framebuf_base *self);
+void fb_prev(framebuf_base *self);
+
+// child class that reads from _target files.
+typedef struct {
+    framebuf_base base; // must be 1st member.
+    
     char *corres_file_base, *linkage_file_base, *prio_file_base;
     char **target_file_base;
 } framebuf;
@@ -94,10 +155,9 @@ typedef struct {
 void fb_init(framebuf *new_buf, int buf_len, int num_cams, int max_targets,\
     char *corres_file_base, char* linkage_file_base, char *prio_file_base,
     char **target_file_base);
-void fb_free(framebuf *self);
-void fb_next(framebuf *self);
-void fb_prev(framebuf *self);
-int fb_read_frame_at_end(framebuf *self, int frame_num, int read_links);
-int fb_write_frame_from_start(framebuf *self, int frame_num);
+
+void fb_disk_free(framebuf_base *self);
+int fb_disk_read_frame_at_end(framebuf_base *self, int frame_num, int read_links);
+int fb_disk_write_frame_from_start(framebuf_base *self, int frame_num);
 
 #endif

--- a/liboptv/include/tracking_run.h
+++ b/liboptv/include/tracking_run.h
@@ -12,7 +12,7 @@
 #include "tracking_frame_buf.h"
 
 typedef struct {
-    framebuf *fb;
+    framebuf_base *fb;
     sequence_par *seq_par;
     track_par *tpar;
     volume_par *vpar;

--- a/liboptv/src/track.c
+++ b/liboptv/src/track.c
@@ -681,7 +681,7 @@ void trackcorr_c_loop (tracking_run *run_info, int step) {
 
     /* Shortcuts into the tracking_run struct */ 
     Calibration **cal;
-    framebuf *fb;
+    framebuf_base *fb;
     track_par *tpar;
     volume_par *vpar;
     control_par *cpar;
@@ -1002,7 +1002,7 @@ double trackback_c (tracking_run *run_info)
     track_par *tpar;
     volume_par *vpar;
     control_par *cpar;
-    framebuf *fb;
+    framebuf_base *fb;
     Calibration **cal;
 
     /* Shortcuts to inside current frame */

--- a/liboptv/src/tracking_frame_buf.c
+++ b/liboptv/src/tracking_frame_buf.c
@@ -556,6 +556,66 @@ int write_frame(frame *self, char *corres_file_base, char *linkage_file_base,
     return 1;
 }
 
+// ----- Virtual functions redirection
+
+void fb_free(framebuf_base *self) {
+    self->_vptr->free(self);
+}
+
+int fb_read_frame_at_end(framebuf_base *self, int frame_num, int read_links) {
+    return self->_vptr->read_frame_at_end(self, frame_num, read_links);
+}
+
+int fb_write_frame_from_start(framebuf_base *self, int frame_num) {
+    return self->_vptr->write_frame_from_start(self, frame_num);
+}
+
+void fb_base_init(framebuf_base *new_buf, int buf_len, int num_cams, int max_targets) {
+    frame *alloc_frame;
+
+    new_buf->buf_len = buf_len;
+    new_buf->num_cams = num_cams;
+
+    new_buf->_ring_vec = (frame **) calloc(buf_len*2, sizeof(frame *));
+    new_buf->buf = new_buf->_ring_vec + buf_len;
+    
+    while (new_buf->buf != new_buf->_ring_vec) {
+        new_buf->buf--;
+        
+        alloc_frame = (frame *) malloc(sizeof(frame));
+        frame_init(alloc_frame, num_cams, max_targets);
+        
+        /* The second half of _ring_vec points to the same objects as the
+           first half. This allows direct indexing like fb->buf[buf_len - 1]
+           even when fb->buf moves forward. */
+        *(new_buf->buf) = alloc_frame;
+        *(new_buf->buf + buf_len) = alloc_frame;
+    }
+    /* Leaves new_buf->buf pointing to the beginning of _ring_vec,
+    which is what we want. */
+    
+    new_buf->_vptr = (fb_vtable*) malloc(sizeof(fb_vtable));
+}
+
+void fb_base_free(framebuf_base *self) {
+    self->buf = self->_ring_vec;
+    
+    while (self->buf != self->_ring_vec + self->buf_len) {
+        free_frame(*(self->buf));
+        free(*(self->buf));
+        self->buf++;
+    }
+    self->buf = NULL;
+    
+    free(self->_ring_vec);
+    self->_ring_vec = NULL;
+    
+    free(self->_vptr);
+    self->_vptr = NULL;
+}
+
+// -------- Specific Implementations of virtual functions.
+
 /* fb_init() allocates a frame buffer object and creates the frames
  * it buffers. The buffer is a ring-buffer based on a double-size vector.
  *  
@@ -574,32 +634,18 @@ void fb_init(framebuf *new_buf, int buf_len, int num_cams, int max_targets,\
     char *corres_file_base, char *linkage_file_base, char *prio_file_base,
     char **target_file_base)
 {
-    frame *alloc_frame;
+    fb_base_init(&new_buf->base, buf_len, num_cams, max_targets);
     
-    new_buf->buf_len = buf_len;
-    new_buf->num_cams = num_cams;
+    // Subclass-specific parameters:
     new_buf->corres_file_base = corres_file_base;
     new_buf->linkage_file_base = linkage_file_base;
     new_buf->prio_file_base = prio_file_base;
     new_buf->target_file_base = target_file_base;
     
-    new_buf->_ring_vec = (frame **) calloc(buf_len*2, sizeof(frame *));
-    new_buf->buf = new_buf->_ring_vec + buf_len;
-    
-    while (new_buf->buf != new_buf->_ring_vec) {
-        new_buf->buf--;
-        
-        alloc_frame = (frame *) malloc(sizeof(frame));
-        frame_init(alloc_frame, num_cams, max_targets);
-        
-        /* The second half of _ring_vec points to the same objects as the
-           first half. This allows direct indexing like fb->buf[buf_len - 1]
-           even when fb->buf moves forward. */
-        *(new_buf->buf) = alloc_frame;
-        *(new_buf->buf + buf_len) = alloc_frame;
-    }
-    /* Leaves new_buf->buf pointing to the beginning of _ring_vec,
-    which is what we want. */
+    // Set up the virtual functions table:
+    new_buf->base._vptr->free = fb_disk_free;
+    new_buf->base._vptr->read_frame_at_end = fb_disk_read_frame_at_end;
+    new_buf->base._vptr->write_frame_from_start = fb_disk_write_frame_from_start;
 }
 
 /* fb_free() frees all memory allocated for the frames and ring vector in a
@@ -608,18 +654,8 @@ void fb_init(framebuf *new_buf, int buf_len, int num_cams, int max_targets,\
  * Arguments:
  * framebuf *self - the framebuf holding the memory to free.
  */
-void fb_free(framebuf *self) {
-    self->buf = self->_ring_vec;
-    
-    while (self->buf != self->_ring_vec + self->buf_len) {
-        free_frame(*(self->buf));
-        free(*(self->buf));
-        self->buf++;
-    }
-    self->buf = NULL;
-    
-    free(self->_ring_vec);
-    self->_ring_vec = NULL;
+void fb_disk_free(framebuf_base *self_base) {
+    fb_base_free(self_base);
 }
 
 /* fb_next() advances the start pointer of the frame buffer, resetting it to the
@@ -628,7 +664,7 @@ void fb_free(framebuf *self) {
  * Arguments:
  * framebuf *self - the framebuf to advance.
  */
-void fb_next(framebuf *self) {
+void fb_next(framebuf_base *self) {
     self->buf++;
     if (self->buf - self->_ring_vec >= self->buf_len)
         self->buf = self->_ring_vec;
@@ -640,7 +676,7 @@ void fb_next(framebuf *self) {
  * Arguments:
  * framebuf *self - the framebuf to advance.
  */
-void fb_prev(framebuf *self) {
+void fb_prev(framebuf_base *self) {
     self->buf--;
     if (self->buf < self->_ring_vec)
         self->buf = self->_ring_vec + self->buf_len - 1;
@@ -656,13 +692,15 @@ void fb_prev(framebuf *self) {
  * Returns:
  * True on success, false on failure.
  */
-int fb_read_frame_at_end(framebuf *self, int frame_num, int read_links) {
+int fb_disk_read_frame_at_end(framebuf_base *self_base, int frame_num, int read_links) {
+    framebuf* self = (framebuf*)self_base;
+    
     if (read_links) {
-        return read_frame(self->buf[self->buf_len - 1], self->corres_file_base,
+        return read_frame(self->base.buf[self->base.buf_len - 1], self->corres_file_base,
             self->linkage_file_base, self->prio_file_base, 
             self->target_file_base, frame_num);
     } else {
-        return read_frame(self->buf[self->buf_len - 1], self->corres_file_base,
+        return read_frame(self->base.buf[self->base.buf_len - 1], self->corres_file_base,
             NULL, NULL, self->target_file_base, frame_num);
     }
 }
@@ -670,14 +708,16 @@ int fb_read_frame_at_end(framebuf *self, int frame_num, int read_links) {
 /* fb_write_frame_from_start() writes the frame to the first position in the ring.
  *
  * Arguments:
- * framebuf *self - the framebuf object doing the reading.
+ * *self - the framebuf object doing the reading.
  * int frame_num - number of the frame to write in the sequence of frames.
  *
  * Returns:
  * True on success, false on failure.
  */
-int fb_write_frame_from_start(framebuf *self, int frame_num) {
-    return write_frame(self->buf[0], self->corres_file_base,
+int fb_disk_write_frame_from_start(framebuf_base *self_base, int frame_num) {
+    framebuf* self = (framebuf*)self_base;
+    
+    return write_frame(self->base.buf[0], self->corres_file_base,
         self->linkage_file_base, self->prio_file_base, self->target_file_base,
         frame_num);
 }

--- a/liboptv/src/tracking_run.c
+++ b/liboptv/src/tracking_run.c
@@ -60,8 +60,8 @@ tracking_run *tr_new(sequence_par *seq_par, track_par *tpar,
     tr->cal = cal;
     tr->flatten_tol = flatten_tol;
     
-    tr->fb = (framebuf *) malloc(sizeof(framebuf));
-    fb_init(tr->fb, buf_len, cpar->num_cams, max_targets,
+    tr->fb = (framebuf_base*) malloc(sizeof(framebuf));
+    fb_init((framebuf*)tr->fb, buf_len, cpar->num_cams, max_targets,
         corres_file_base, linkage_file_base, prio_file_base, seq_par->img_base_name);
     
     tr->lmax = norm((tpar->dvxmin - tpar->dvxmax), \


### PR DESCRIPTION
Implementation of the frame buffer as a base class and one child class (doing the disk read). It should not be too hard after this work to implement a memory reader. I just don't have access to the format you intend to work with.

Once two or more frame-buffer children exist, you need to change tr_new so that it can choose the one you need, or just to pass it from outside.

I also re-enabled GNU Check. It was very useful when debugging. Please don't neglect it.
Feel free to call me if you want to discuss what happens here.